### PR TITLE
ISSUE-01 fix url that middleware redirects unauthenticated users to

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,7 +25,7 @@ export default async function middleware(req: NextRequest) {
     // Redirect to /login if the user is not authenticated
     if (isProtectedRoute && !user) {
         console.log("[middleware] Rerouting to login.");
-        return NextResponse.redirect(new URL("/login", req.nextUrl));
+        return NextResponse.redirect(new URL("/auth/login", req.nextUrl));
     }
 
     // Redirect to /dashboard if the user is authenticated

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -13,7 +13,7 @@ test("redirects if not authenticated", async ({ page }) => {
     await page.goto("/dashboard");
 
     // Expects URL to redirect to dashboard.
-    await expect(page).toHaveURL(/.*login/);
+    await expect(page).toHaveURL("/auth/login");
 });
 
 test("login failure", async ({ page }) => {


### PR DESCRIPTION
### Background

Fixed a bug where unauthenticated users were redirected to a page showing 404, instead of the Login page.

### Steps to Reproduce
commit: 605b463
environment: dev

1. (be logged out)
2. navigate to `/dashboard`

### Expected Results

Redirected to `/auth/login`

![image](https://github.com/user-attachments/assets/5b8d87da-cc86-4f99-bb87-5d15c9b7ef52)

### Actual Results

Redirected to `/login`

![image](https://github.com/user-attachments/assets/27ef20b7-fb75-4e13-848a-721f70663fc3)


