### PR TITLE
Issue 02 missing auth for dashboard subpages

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,8 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { verifyAuth } from "@/lib/auth";
 
-const protectedRoutes = ["/dashboard", "/logout"];
-const publicRoutes = ["/login", "/register", "/"];
+const publicRoutes = ["/auth/login", "/auth/register", "/"];
+
+function checkProtectedRoute(path: string) {
+    return path.startsWith("/dashboard");
+}
 
 /**
  * On every request, this middleware is run to:
@@ -15,7 +18,7 @@ export default async function middleware(req: NextRequest) {
     const path = req.nextUrl.pathname;
     console.log("[middleware] Accessing page:", path);
 
-    const isProtectedRoute = protectedRoutes.includes(path);
+    const isProtectedRoute = checkProtectedRoute(req.nextUrl.pathname);
     const isPublicRoute = publicRoutes.includes(path);
 
     // Decrypt the session from the cookie
@@ -29,11 +32,7 @@ export default async function middleware(req: NextRequest) {
     }
 
     // Redirect to /dashboard if the user is authenticated
-    if (
-        isPublicRoute &&
-        user &&
-        !req.nextUrl.pathname.startsWith("/dashboard")
-    ) {
+    if (isPublicRoute && user) {
         console.log("[middleware] Rerouting to dashboard.");
         return NextResponse.redirect(new URL("/dashboard", req.nextUrl));
     }

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -9,11 +9,19 @@ test("has title", async ({ page }) => {
     await expect(page).toHaveTitle(/Login/);
 });
 
-test("redirects if not authenticated", async ({ page }) => {
-    await page.goto("/dashboard");
+[
+    "/dashboard",
+    "/dashboard/home",
+    "/dashboard/onboarding",
+    "/dashboard/onboarding/background",
+    "/dashboard/onboarding/personal",
+].forEach((pageUrl) => {
+    test(`redirects ${pageUrl} if not authenticated`, async ({ page }) => {
+        await page.goto(pageUrl);
 
-    // Expects URL to redirect to dashboard.
-    await expect(page).toHaveURL("/auth/login");
+        // Expects URL to redirect to dashboard.
+        await expect(page).toHaveURL("/auth/login");
+    });
 });
 
 test("login failure", async ({ page }) => {


### PR DESCRIPTION
### Background

Fixed a bug where unauthenticated users weren't from any dashboard subpages to the the Login page. This occurred because `isProtectedRoute = protectedRoutes.includes(path)` returned true only for exact matches to any of the strings in the `protectedRoutes` list, and all of the dashboard subpages were missing from `protectedRoutes`. This was fixed by setting `isProtectedRoute` to true if the requested path starts with `/dashboard` .

We also add the some of the subpages to our e2e Playwright tests so we are sure we don't break this in the future.

### Steps to Reproduce
commit: 605b463
environment: dev

1. (be logged out)
2. navigate to `/dashboard/onboarding`

### Expected Results

Redirected to `/auth/login`

### Actual Results

Not redirected